### PR TITLE
Could safeguard like this

### DIFF
--- a/test.js
+++ b/test.js
@@ -104,6 +104,17 @@ magic.h = 5
 ok(wtb(magic).area === 15)
 log("magic works")
 
+const parent = { width: 3, height: () => 5 }
+const child = Object.create(parent)
+ok(wtb(child).area === 15)
+log("inheritable")
+
+const antipattern = Object.prototype
+antipattern.width = 2
+ok(wtb({height: 3}).area === 9)
+delete antipattern.width
+log("prototype safe")
+
 ok(wtb(true).area === 1)
 ok(wtb(true).aspect === 1)
 ok(wtb(true).width === 1)

--- a/wtb.js
+++ b/wtb.js
@@ -8,8 +8,13 @@
   var aspect = "aspect"
   var height = "height"
   var width = "width"
+  var probe = Object.getPrototypeOf
+  var prone = Object.prototype
+  var own = prone.hasOwnProperty
 
   function get(o, k) {
+    var ban = probe && prone === probe(o) && !own.call(o, k)
+    if (ban) return
     var v = o[k]
     return typeof v == "function" ? v.call(o) : v
   }


### PR DESCRIPTION
Somewhat protect from `Object.prototype` antipatterns