### PR TITLE
Own values on plain objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install wtb --save
 const wtb = require("wtb")
 ```
 
-### `wtb(dimensions=0)`
+### `wtb(dimensions=0)  `
 
 * dimensions are accepted in many formats shown in examples
 * defaults to square
@@ -18,7 +18,7 @@ const wtb = require("wtb")
 * handles any input without throwing errors
 * string delimiter is any non numeric portion
 * supports JavaScript number formats including integers, decimals, scientific notation
-* dimension support includes dimensions methods like in a jQuery object like `wtb($(window))`
+* plain objects support owned values while null objects support any depth
 * returns an object with calculated properties whose values range from `0` to `Infinity`
   * `area` is the calculated `width * height`
   * `aspect` is the calculated aspect ratio `width / height`
@@ -46,6 +46,7 @@ wtb([30])
 wtb([30, 30])
 wtb({ width: 30 })
 wtb({ height: 30 })
+wtb({ width: () => 30 })
 ```
 
 they return a square object
@@ -72,6 +73,7 @@ wtb("3e2x2e2")
 wtb([30, 20])
 wtb([30, 30])
 wtb({ width: 30, height: 20 })
+wtb({ width: () => 30, height: () => 20 })
 ```
 
 they return a rectangular object

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install wtb --save
 const wtb = require("wtb")
 ```
 
-### `wtb(dimensions=0)  `
+### `wtb(dimensions=0)`
 
 * dimensions are accepted in many formats shown in examples
 * defaults to square

--- a/test.js
+++ b/test.js
@@ -94,26 +94,15 @@ ok(wtb({width:"333", height:"22"}).width === 333)
 ok(wtb({width:"333", height:"22"}).height === 22)
 log("2d objects work")
 
-function mage() {}
-const model = mage.prototype
-model.width = function() { return this.w }
-model.height = function() { return this.h }
-const magic = new mage
-magic.w = 3
-magic.h = 5
+const magic = {}
+const trick = Object.create(null)
+const thief = Object.create(magic)
+magic.width = trick.width = () => 3
+magic.height = trick.height = () => 5
 ok(wtb(magic).area === 15)
-log("magic works")
-
-const parent = { width: 3, height: () => 5 }
-const child = Object.create(parent)
-ok(wtb(child).area === 15)
-log("inheritable")
-
-const antipattern = Object.prototype
-antipattern.width = 2
-ok(wtb({height: 3}).area === 9)
-delete antipattern.width
-log("prototype safe")
+ok(wtb(trick).area === 15)
+ok(wtb(thief).area === 0)
+log("magic safe")
 
 ok(wtb(true).area === 1)
 ok(wtb(true).aspect === 1)

--- a/wtb.js
+++ b/wtb.js
@@ -8,19 +8,18 @@
   var aspect = "aspect"
   var height = "height"
   var width = "width"
-  var probe = Object.getPrototypeOf
-  var prone = Object.prototype
-  var own = prone.hasOwnProperty
+  var own = {}.hasOwnProperty
 
   function get(o, k) {
-    var ban = probe && prone === probe(o) && !own.call(o, k)
+    var ban = o instanceof Object && !own.call(o, k)
     if (ban) return
     var v = o[k]
     return typeof v == "function" ? v.call(o) : v
   }
 
   function wtb(given) {
-    var num = +given
+    var sob = typeof given == "object" != given instanceof Object
+    var num = sob && given ? NaN : +given
     var met = num === num || !given
     ? [num]
     : given.match === match


### PR DESCRIPTION
Safer than #7

- Only honor owned properties for plain objects
- Honor any depth value on `null` prototype chains 
- Tests and examples included
